### PR TITLE
Fix nm-applet autostart echo

### DIFF
--- a/autostart.sh
+++ b/autostart.sh
@@ -484,7 +484,7 @@ fi &
 while :; do
     sleep 10
     if iconf -i wifiapplet && ! pgrep nm-applet; then
-        echo "starting bluetooth applet"
+        echo "starting wifi applet"
         nm-applet &
     fi
 


### PR DESCRIPTION
In autostart.sh there was a typo, it printed "starting bluetooth applet" even tho it was starting the nm-applet