### PR TITLE
pass additional arguments through to default apps

### DIFF
--- a/setup/defaultapps
+++ b/setup/defaultapps
@@ -26,7 +26,7 @@ setprogram() {
     if command -v "$TEMPSETTING"; then
         ln -s "$(which "$TEMPSETTING")" ./"$1"
     else
-        echo "$TEMPSETTING" >"$1"
+        echo "$TEMPSETTING" '"$@"' >"$1"
         chmod +x "$1"
     fi
 }


### PR DESCRIPTION
Fixes a few bugs with a common cause where e.g. instantsettings' "edit autostart" option doesn't work because the file name is not passed to the default editor or things like `instantutils open <XXX> <args...> ` ignores the additional args.