### PR TITLE
update killwm to support instantruntimedir

### DIFF
--- a/programs/killwm
+++ b/programs/killwm
@@ -2,16 +2,20 @@
 
 # restart instantWM from cli
 
-if ! [ -e /tmp/wmpid ]; then
+# setup runtime dir variable 
+RTD="$(instantruntimedir)"
+RTD=${RTD:-'/tmp/instantos'}
+
+if ! [ -e "$RTD"/wmpid ]; then
     if pgrep instantwm; then
         pkill instantwm
         exit
     fi
 else
-    WMPID="$(cat /tmp/wmpid)"
+    WMPID="$(cat "$RTD"/wmpid)"
     if kill -0 "$WMPID"; then
         kill "$WMPID"
-        rm /tmp/wmpid
+        rm "$RTD"/wmpid
         exit
     fi
 fi


### PR DESCRIPTION
Makes killwm use the same runtime directory as `startinstantos` so that it doesn't look for wmpid in the wrong place
I'm using the var name RTD because thats what was used in [startinstantos](https://github.com/instantOS/instantWM/blob/master/startinstantos)