### PR TITLE
temp theme fix. battery status fix/update. color update.

### DIFF
--- a/status.sh
+++ b/status.sh
@@ -38,7 +38,7 @@ while :; do
 
     # battery indicator on laptop
     if [ -n "$ISLAPTOP" ]; then
-        TMPBAT=$(acpi)
+        TMPBAT=$(acpi | grep -iv Unknown | head -1)
         if [[ $TMPBAT =~ "Charging" ]]; then
             BATTERY="^c$GREEN^^t$DARKTEXT^  B$(echo "$TMPBAT" | grep -oP '\d+(?=%)')% "
         elif [[ $TMPBAT =~ "Discharging" ]]; then


### PR DESCRIPTION
- instantthemes and battery bug fix

(Instantthemes)
/usr/bin/instantstatus
the line containing "instantthemes apply" is resetting theming set by user.
even if settings>appearance>auto theming is turned off.
autotheming seems do do exactly that "instantthemes apply".
instantthemes is planned to have a rework, but till then this should also be more welcoming to new users / new installs of instantOS since it breaks the icons/theme of rofi and the statusbar as well as some other theming.

(Battery)
increased the battery threshold to 20%, battery low warning for older batteries/laptops. 
at 10% the battery can be almost empty already, so the warning can be late. 

(Extra)
added extra colors to get distinction between internet and battery background color.
new color coding: yellow=discharging, green=charging, red=warning low battery, black=neither charging/discharging.

ill be happy to remove the new colors for better distinction between battery and internet or battery threshold back to 10%. so we atleast have battery bug fixed (gives error in log)



